### PR TITLE
Fixed "runtime error: invalid memory address or nil pointer dereference"

### DIFF
--- a/endpoints.json
+++ b/endpoints.json
@@ -448,6 +448,7 @@
   {
     "name": "users.info",
     "return": "objects.User",
+    "json": "user",
     "args": [
       {
         "name": "user",
@@ -459,6 +460,7 @@
   {
     "name": "users.list",
     "return": "objects.UserList",
+    "json": "members",
     "args": [
       {
         "name": "presence",

--- a/internal/cmd/genmethods/genmethods.go
+++ b/internal/cmd/genmethods/genmethods.go
@@ -27,6 +27,7 @@ type Endpoint struct {
 	methodName string
 	Group      string     `json:"group,omitempty"`
 	Name       string     `json:"name"` // e.g. "chat.PostMessage"
+	JSON       string     `json:"json"`
 	Args       []Argument `json:"args,omitempty"`
 	ReturnType string     `json:"return,omitempty"`
 	SkipToken  bool       `json:"skip_token,omitempty"`
@@ -104,7 +105,7 @@ func _main() error {
 func generateServicesFile(groups map[string]struct{}) error {
 	var list []string
 	for k := range groups {
-		list =append(list, k)
+		list = append(list, k)
 	}
 	sort.Strings(list)
 
@@ -334,6 +335,9 @@ func generateServiceDetailsFile(file string, endpoints []Endpoint) error {
 		if hasReturn {
 			buf.WriteByte('\n')
 			buf.WriteString(returnType)
+			if endpoint.JSON != "" {
+				buf.WriteString(fmt.Sprintf(" `json:\"%s\"`", endpoint.JSON))
+			}
 		}
 		buf.WriteString("\n}")
 		buf.WriteString("\nif err := c.service.client.postForm(ctx, endpoint, v, &res); err != nil {")

--- a/users.go
+++ b/users.go
@@ -102,7 +102,7 @@ func (c *UsersInfoCall) Do(ctx context.Context) (*objects.User, error) {
 	}
 	var res struct {
 		SlackResponse
-		*objects.User
+		*objects.User `json:"user"`
 	}
 	if err := c.service.client.postForm(ctx, endpoint, v, &res); err != nil {
 		return nil, errors.Wrap(err, `failed to post to users.info`)
@@ -147,7 +147,7 @@ func (c *UsersListCall) Do(ctx context.Context) (objects.UserList, error) {
 	}
 	var res struct {
 		SlackResponse
-		objects.UserList
+		objects.UserList `json:"members"`
 	}
 	if err := c.service.client.postForm(ctx, endpoint, v, &res); err != nil {
 		return nil, errors.Wrap(err, `failed to post to users.list`)


### PR DESCRIPTION
This issue because of invalid struct generated by `genmethods` command.
## Issue example
From slack api: `user.info`
```json
{
"ok": true,
"user": {
    "color": "e0a729",
    "deleted": false,
    "id": "U295YG6RY",
    "is_admin": false,
    "is_bot": true,
    "is_owner": false,
    "is_primary_owner": false,
    "is_restricted": false,
    "is_ultra_restricted": false,
    "name": "salmon",
    "profile": {
      "api_app_id": "",
      "avatar_hash": "227d01b41bee",
      "bot_id": "B2941662F",
      "first_name": "あの時の鮭",
      "image_1024": "https://avatars.slack-edge.com/2016-09-08/77196903857_227d01b41bee70114e05_48.png",
      "image_192": "https://avatars.slack-edge.com/2016-09-08/77196903857_227d01b41bee70114e05_48.png",
      "image_24": "https://avatars.slack-edge.com/2016-09-08/77196903857_227d01b41bee70114e05_24.png",
      "image_32": "https://avatars.slack-edge.com/2016-09-08/77196903857_227d01b41bee70114e05_32.png",
      "image_48": "https://avatars.slack-edge.com/2016-09-08/77196903857_227d01b41bee70114e05_48.png",
      "image_512": "https://avatars.slack-edge.com/2016-09-08/77196903857_227d01b41bee70114e05_48.png",
      "image_72": "https://avatars.slack-edge.com/2016-09-08/77196903857_227d01b41bee70114e05_48.png",
      "image_original": "https://avatars.slack-edge.com/2016-09-08/77196903857_227d01b41bee70114e05_original.png",
      "real_name": "あの時の鮭",
      "real_name_normalized": "あの時の鮭"
    },
    "real_name": "あの時の鮭",
    "status": null,
    "team_id": "T080KNURY",
    "tz": null,
    "tz_label": "Pacific Daylight Time",
    "tz_offset": -25200,
    "updated": 1473266051
  }
}
```
Result `var res` struct on [users.go](https://github.com/lestrrat/go-slack/blob/310681bec545badd3137d4c9591270a279498da9/users.go#L103-L106) then decoded json:
```go
struct { slack.SlackResponse; *objects.User }{
  SlackResponse: slack.SlackResponse{
    OK:      true,
    ReplyTo: 0,
    Error:   slack.ErrorResponse{
      Code:    0,
      Message: "",
    },
    Timestamp: "",
  },
  User: (*objects.User)(nil),
}
```
## Comment
I could fix issue by embedding json tag this PR, But I did not know why it was not decoded by field name.