### PR TITLE
Remove dependency on other slack library

### DIFF
--- a/events/events.go
+++ b/events/events.go
@@ -3,7 +3,7 @@ package events
 import (
 	"encoding/json"
 
-	"github.com/nlopes/slack"
+	"github.com/lestrrat/go-slack/objects"
 	"github.com/pkg/errors"
 )
 
@@ -30,7 +30,7 @@ func (p *eventUnmarshalProxy) Populate(e *Event) error {
 	// TODO: Add more types
 	switch p.Type {
 	case MessageChannelsType, MessageGroupsType, MessageImType, MessageMpimType:
-		item = &slack.Message{}
+		item = &objects.Message{}
 	default:
 		return errors.Errorf("unknown event type: %s", p.Type)
 	}


### PR DESCRIPTION
This doesn't seem to be required, and it brings a BSD-licensed library in as a dep of this library.