### PR TITLE
Use proper json keys for marshal/unmarshal

### DIFF
--- a/channels_gen.go
+++ b/channels_gen.go
@@ -454,7 +454,7 @@ func (c *ChannelsInfoCall) Do(ctx context.Context) (*objects.Channel, error) {
 	}
 	var res struct {
 		objects.GenericResponse
-		*objects.Channel
+		*objects.Channel `json:"channel"`
 	}
 	if err := c.service.client.postForm(ctx, endpoint, v, &res); err != nil {
 		return nil, errors.Wrap(err, `failed to post to channels.info`)

--- a/channels_gen.go
+++ b/channels_gen.go
@@ -526,7 +526,7 @@ func (c *ChannelsInviteCall) Do(ctx context.Context) (*objects.Channel, error) {
 	}
 	var res struct {
 		objects.GenericResponse
-		*objects.Channel
+		*objects.Channel `json:"channel"`
 	}
 	if err := c.service.client.postForm(ctx, endpoint, v, &res); err != nil {
 		return nil, errors.Wrap(err, `failed to post to channels.invite`)

--- a/channels_test.go
+++ b/channels_test.go
@@ -165,24 +165,6 @@ func TestChannelsHistoryUnit(t *testing.T) {
 	}
 }
 
-func TestChannelsInfoUnit(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	s := httptest.NewServer(newDummyServer())
-	defer s.Close()
-
-	c := newSlackWithDummy(s)
-	channel, err := c.Channels().Info("foo").IncludeLocale(true).Do(ctx)
-	if !assert.NoError(t, err, "Info should succeed") {
-		return
-	}
-
-	if !assert.NotNil(t, channel, "channel should not be nil") {
-		return
-	}
-}
-
 func TestChannelsInviteUnit(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/channels_test.go
+++ b/channels_test.go
@@ -173,8 +173,12 @@ func TestChannelsInfoUnit(t *testing.T) {
 	defer s.Close()
 
 	c := newSlackWithDummy(s)
-	_, err := c.Channels().Info("foo").IncludeLocale(true).Do(ctx)
+	channel, err := c.Channels().Info("foo").IncludeLocale(true).Do(ctx)
 	if !assert.NoError(t, err, "Info should succeed") {
+		return
+	}
+
+	if !assert.NotNil(t, channel, "channel should not be nil") {
 		return
 	}
 }

--- a/endpoints.json
+++ b/endpoints.json
@@ -96,6 +96,7 @@
     "name": "channels.info",
     "proxy": true,
     "return": "objects.Channel",
+    "json": "channel",
     "args": [
       {
         "name": "channel",

--- a/endpoints.json
+++ b/endpoints.json
@@ -113,6 +113,7 @@
   {
     "name": "channels.invite",
     "return": "objects.Channel",
+    "json": "channel",
     "args": [
       {
         "name": "channel",

--- a/server/mockserver/response.go
+++ b/server/mockserver/response.go
@@ -104,7 +104,7 @@ func stockObjectsAuthTestResponse() interface{} {
 func stockObjectsChannel() interface{} {
 	var r = struct {
 		objects.GenericResponse
-		objects.Channel
+		objects.Channel `json:"channel"`
 	}{
 		GenericResponse: StockResponse("dummy").(objects.GenericResponse),
 		Channel:         ChannelJedis,


### PR DESCRIPTION
A couple of omissions in endpoints.json made channels.info and channels.invite return empty values on success.

fixes #46